### PR TITLE
Allow containers to bind to ship IP instead of only 0.0.0.0

### DIFF
--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -34,16 +34,18 @@ class Ship(Entity):
     DEFAULT_DOCKER_VERSION = '1.6'
     DEFAULT_DOCKER_TIMEOUT = 5
 
-    def __init__(self, name, ip, docker_port=DEFAULT_DOCKER_PORT, timeout=None):
+    def __init__(self, name, ip, docker_port=DEFAULT_DOCKER_PORT, timeout=None, bind_to_ip=False):
         """Instantiate a new ship.
 
         Args:
             name (string): the name of the ship.
             ip (string): the IP address of resolvable host name of the host.
             docker_port (int): the port the Docker daemon listens on.
+            bind_to_ip (bool): bind containers to their ship IP or 0.0.0.0
         """
         Entity.__init__(self, name)
         self._ip = ip
+        self._bind_to_ip = bind_to_ip
         self._docker_port = docker_port
 
         self._backend_url = 'http://{:s}:{:d}'.format(ip, docker_port)
@@ -75,7 +77,7 @@ class Service(Entity):
     """A Service is a collection of Containers running on one or more Ships
     that constitutes a logical grouping of containers that make up an
     infrastructure service.
-    
+
     Services may depend on each other. This dependency tree is honored when
     services need to be started.
     """
@@ -269,7 +271,7 @@ class Container(Entity):
         doesn't expose any ports, return the container status instead. If the
         container exposes multiple ports, as soon as one port is active the
         application inside the container is considered to be up and running.
-        
+
         Args:
             retries (int): number of attempts (timeout is 1 second).
         """

--- a/maestro/maestro.py
+++ b/maestro/maestro.py
@@ -21,7 +21,8 @@ class Conductor:
         self._ships = dict((k, entities.Ship(k, v['ip'],
                                              docker_port=v.get('docker_port',
                                                                entities.Ship.DEFAULT_DOCKER_PORT),
-                                             timeout=v.get('timeout')))
+                                             timeout=v.get('timeout'),
+                                             bind_to_ip=v.get('bind_to_ip')))
             for k, v in self._config['ships'].iteritems())
 
         # Register defined private Docker registries authentications

--- a/maestro/plays.py
+++ b/maestro/plays.py
@@ -262,9 +262,13 @@ class Start(BaseOrchestrationPlay):
                     'Container status could not be obtained after creation!'
         o.commit('\033[32;1m{:<15s}\033[;0m'.format(container.id[:7]))
 
+        if container.ship._bind_to_ip:
+        	ip = container.ship.ip
+        else:
+        	ip = "0.0.0.0"
         o.pending('starting container {}...'.format(container.id[:7]))
         ports = container.ports and dict([
-            (port['exposed'], ('0.0.0.0', port['external']))
+            (port['exposed'], (ip, port['external']))
                 for port in container.ports.itervalues()]) or None
         container.ship.backend.start(container.id,
             binds=container.volumes,


### PR DESCRIPTION
First, let me say thank you for the awesome tool you've created!

Onto the important bit:

```
Finally, Maestro makes the choice of using one-to-one port mappings from
the container to the host. This _may_ change in the future, but for now
this simplifies things:

* it means Maestro doesn't have to do a lot of introspection on the
  containers to figure out which external port Docker assigned them;
* it makes it a bit easier for troubleshooting as port numbers are the
  same inside and outside the containers;
* some services (Cassandra is one example) assume that all their nodes
  use the same port(s).
```

I agree that it greatly simplifies things for your code **and** for users, however, I have a slight issue with this because: I want to iterate and build my Docker images/formation using maestro in a Vagrant VM before I ship to production.

Side note: we've actually talked on IRC about Docker overhead and discussed performance testing. I still plan to do that but I need to get this working first :). What's funny is we're both doing this for ZK/Kafka!

Here's my use-case: I am using Vagrant to host Docker and make a "dev env" which simulates multiple data centers by defining private networks:

``` ruby
# Vagrantfile
# DC1
config.vm.network "private_network", ip: "192.168.50.2"
# DC2
config.vm.network "private_network", ip: "192.168.60.2"
# DC3
config.vm.network "private_network", ip: "192.168.61.2"
```

Then, I use `iptables` so I can trick maestro into thinking each IP is running docker via: 

`iptables -t nat -A OUTPUT -p tcp --dport 4243 -j DNAT --to-destination 10.0.2.15:4243`

Then I define my multiple data centers in formation.yml:

``` yml
ships:
  dc1:
    ip: 192.168.50.2
  dc2:
    ip: 192.168.60.2
  dc3:
    ip: 192.168.61.2
```

This setup allows me to effectively simulate a multiple data center Kafka formation. The problem is that maestro binds each container to `0.0.0.0` which means I can only launch a single container. This PR allows the user to specify binding to the ship's IP rather than `0.0.0.0` so that I can circumvent this issue along with not having to do  Docker port mapping.

Please let me know what you think. I'm not married to the config option or my implementation and this is my first time ever writing Python. Feel free to rip it apart :)
