### PR TITLE
Specify volumes for create_container

### DIFF
--- a/maestro/plays.py
+++ b/maestro/plays.py
@@ -302,6 +302,7 @@ class Start(BaseOrchestrationPlay):
             hostname=container.name,
             name=container.name,
             environment=container.env,
+            volumes=container.volumes.values(),
             ports=ports)
 
         o.pending('waiting for container creation...')


### PR DESCRIPTION
Binding the volumes on container start wasn't enough to have the volumes mounted. Specifying the volumes on container creation is also required.
