### PR TITLE
Unable to bind one port to multiple interfaces

### DIFF
--- a/maestro/plays.py
+++ b/maestro/plays.py
@@ -318,8 +318,8 @@ class Start(BaseOrchestrationPlay):
         ports = defaultdict(list) if container.ports else None
         if ports is not None:
             for port in container.ports.itervalues():
-                ports[port['exposed']].append((port['external'][0],
-                                port['external'][1].split('/')[0]))
+                ports[port['exposed']].append(
+                    (port['external'][0], port['external'][1].split('/')[0]))
 
         container.ship.backend.start(container.id,
                                      binds=container.volumes,


### PR DESCRIPTION
This fixes https://github.com/signalfuse/maestro-ng/issues/14 on my machine.
When constructing dict from a list of tuples, if two keys have the same name, only one will get used.
This prevents multiple ports entries using the same port but mapping on different interfaces.
Instead, for each port entry, a list of mappings should be given.
