### PR TITLE
Fix detach

### DIFF
--- a/maestro/plays.py
+++ b/maestro/plays.py
@@ -306,7 +306,8 @@ class Start(BaseOrchestrationPlay):
             name=container.name,
             environment=container.env,
             volumes=container.volumes.values(),
-            ports=ports)
+            ports=ports,
+            detach=True)
 
         o.pending('waiting for container creation...')
         if not self._wait_for_status(container, lambda x: x):


### PR DESCRIPTION
Docker-py sets the detach flag to False by default, causing improper flags passed on later on to the Docker REST API.
Therefore, I added a detach=True flag.
