### PR TITLE
Fixed entry_points scripts for setup.py

### DIFF
--- a/maestro/__main__.py
+++ b/maestro/__main__.py
@@ -57,7 +57,7 @@ def create_parser():
     return parser
 
 
-def main(args):
+def main(args=None):
     options = create_parser().parse_args(args)
     config = load_config(options)
 
@@ -92,5 +92,6 @@ def main(args):
     except KeyboardInterrupt:
         return 1
 
+
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
     ],
 
     entry_points={
-        'console': ['maestro = maestro.maestro'],
-        'setuptools.installation': ['eggsecutable = maestro.maestro:main'],
+        'console_scripts': ['maestro = maestro.__main__:main'],
+        'setuptools.installation': ['eggsecutable = maestro.__main__:main'],
     },
 
     author='Maxime Petazzoni',


### PR DESCRIPTION
`setup.py` uses the `entry_points` argument to the `setup` function, but it's syntax was incorrect: to generate a standalone script, one has to use `console_scripts` instead of `console`.

Using this, after install you can execute `maestro -f file.yaml` instead of `python -m maestro -f file.yaml`, although the latter still works.

All tests passed with `tox`.
