### PR TITLE
added empty prefix to pip install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Installation
 You can install Maestro via _Pip_:
 
 ```
-$ pip install --user --upgrade git+git://github.com/signalfuse/maestro-ng
+$ pip install --user --prefix= --upgrade git+git://github.com/signalfuse/maestro-ng
 ```
 
 Orchestration


### PR DESCRIPTION
Without clearing my prefix I got the following error on OSX when installing maestro-ng via pip.

```
running install

error: can't combine user with prefix, exec_prefix/home, or install_(plat)base
```

This could be just a newbie mistake on my part but I think I have a straightforward python environment, installed via Homebrew.

Full pip log is here: https://gist.github.com/ralph-tice/dbde543c526d64f834a5

I got sent down this resolution path by reading http://stackoverflow.com/questions/4495120/combine-user-with-prefix-error-with-setup-py-install but didn't see the --prefix= comment until after I used ~/.pydistutils.cfg to manage my prefix instead, which I've since deleted.
