### PR TITLE
Add support for docker -dns

### DIFF
--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -280,6 +280,9 @@ class Container(Entity):
         # Should this container run with -privileged?
         self.privileged = config.get('privileged', False)
 
+        # -dns value
+        self.dns = config.get('dns')
+
         # Stop timeout
         self.stop_timeout = config.get('stop_timeout', 10)
 

--- a/maestro/plays.py
+++ b/maestro/plays.py
@@ -405,6 +405,7 @@ class Start(BaseOrchestrationPlay):
             cpu_shares=container.cpu_shares,
             ports=ports,
             detach=True,
+            dns=container.dns,
             command=container.cmd)
 
         o.pending('waiting for container creation...')

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -63,6 +63,13 @@ class ContainerTest(unittest.TestCase):
             self.assertIn(k, container.env)
             self.assertEqual(v, container.env[k])
 
+    def test_dns_option(self):
+        service_env = {'ENV_VAR': 'value'}
+        container_env = {'OTHER_ENV_VAR': 'other-value'}
+        service = entities.Service('foo', 'stackbrew/ubuntu', service_env)
+        container = entities.Container('foo1', entities.Ship('ship', 'shipip'),
+                                       service, config={'env': container_env, 'dns': '8.8.8.8'})
+        self.assertEqual('8.8.8.8', container.dns)
 
 class BaseConfigUsingTest(unittest.TestCase):
 


### PR DESCRIPTION
For cases where the docker daemon is not already using the `-dns` config
