### PR TITLE
add pull command that just refreshes images without starting containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,13 +678,14 @@ contains the path to your `maestro-ng` repository clone and using
 ```
 $ maestro -h
 usage: maestro [-h] [-f FILE] [-v]
-               {status,start,stop,restart,logs,deptree} ...
+               {status,pull,start,stop,restart,logs,deptree} ...
 
 Maestro, Docker container orchestrator.
 
 positional arguments:
-  {status,start,stop,restart,logs,deptree}
+  {status,pull,start,stop,restart,logs,deptree}
     status              display container status
+    pull                pull images from repository
     start               start services and containers
     stop                stop services and containers
     restart             restart services and containers

--- a/maestro/__main__.py
+++ b/maestro/__main__.py
@@ -100,6 +100,13 @@ def create_parser():
         '-F', '--full', action='store_true',
         help='show full status with port state')
 
+    # pull
+    subparser = subparsers.add_parser(
+        parents=[common, concurrent],
+        name='pull',
+        description='Pull container images from registry',
+        help='pull container images from registry')
+
     # start
     subparser = subparsers.add_parser(
         parents=[common, concurrent, with_refresh],

--- a/maestro/maestro.py
+++ b/maestro/maestro.py
@@ -245,6 +245,28 @@ class Conductor:
         else:
             plays.Status(containers, concurrency).run()
 
+    def pull(self, things, with_dependencies=False,
+             ignore_dependencies=False, concurrency=None, **kwargs):
+        """Force an image pull to refresh images for the given services and
+        containers. Dependencies of the requested containers and services are
+        pulled first.
+
+        Args:
+            things (set<string>): The list of things to pull.
+            with_dependencies (boolean): Whether to act on only the specified
+                things, or their dependencies as well.
+            ignore_dependencies (boolean): Whether dependency order should be
+                respected.
+            concurrency (int): The maximum number of instances that can be
+                acted on at the same time.
+        """
+        containers = self._ordered_containers(things) \
+            if with_dependencies else self._to_containers(things)
+
+        self._audit_play(
+            plays.Pull(containers, self.registries,
+                       ignore_dependencies, concurrency))
+
     def start(self, things, refresh_images=False, with_dependencies=False,
               ignore_dependencies=False, concurrency=None, **kwargs):
         """Start the given container(s) and services(s). Dependencies of the

--- a/maestro/plays/__init__.py
+++ b/maestro/plays/__init__.py
@@ -254,6 +254,27 @@ class Start(BaseOrchestrationPlay):
                                           self._refresh_images))
 
 
+class Pull(BaseOrchestrationPlay):
+    """A Maestro orchestration play that will force an image pull to refresh
+       images for the given services and containers."""
+
+    def __init__(self, containers=[], registries={},
+                 ignore_dependencies=True, concurrency=None):
+        BaseOrchestrationPlay.__init__(
+            self, containers, ignore_dependencies=ignore_dependencies,
+            concurrency=concurrency)
+
+        self._registries = registries
+
+    def _run(self):
+        for order, container in enumerate(self._containers):
+            o = self._om.get_formatter(order, prefix=(
+                BaseOrchestrationPlay.LINE_FMT.format(
+                    order + 1, container.name, container.service.name,
+                    container.ship.address)))
+            self.register(tasks.PullTask(o, container, self._registries))
+
+
 class Stop(BaseOrchestrationPlay):
     """A Maestro orchestration play that will stop the containers of the
     requested services. The list of containers should be provided reversed so

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -169,9 +169,7 @@ class StartTask(Task):
                 not filter(
                     lambda i: self.container.service.image in i['RepoTags'],
                     self.container.ship.backend.images(image['repository'])):
-            # First, attempt to login if we can/need to.
-            LoginTask(self.o, self.container, self._registries).run()
-            PullTask(self.o, self.container).run()
+            PullTask(self.o, self.container, self._registries).run()
 
         # Create and start the container.
         ports = self.container.ports \
@@ -328,12 +326,17 @@ class LoginTask(Task):
 class PullTask(Task):
     """Pull (download) the image a container is based on."""
 
-    def __init__(self, o, container):
+    def __init__(self, o, container, registries={}):
         Task.__init__(self, o, container)
+        self._registries = registries
         self._progress = {}
 
     def run(self):
         self.o.reset()
+
+        # First, attempt to login if we can/need to.
+        LoginTask(self.o, self.container, self._registries).run()
+
         self.o.pending('pulling image {}...'
                        .format(self.container.service.image))
         image = self.container.service.get_image_details()


### PR DESCRIPTION
so that you can do all the slow pulling without a concurrency limit (no --concurrency argument) and then rolling restarts with limited concurrency
