### PR TITLE
allow ansi output to be forced using ANSICON environment variable

### DIFF
--- a/maestro/plays/__init__.py
+++ b/maestro/plays/__init__.py
@@ -6,12 +6,11 @@ from __future__ import print_function
 
 import functools
 import threading
-import sys
 
 from . import tasks
 from .. import exceptions
 from .. import termoutput
-from ..termoutput import green, red
+from ..termoutput import green, red, supports_color
 
 
 class BaseOrchestrationPlay:
@@ -27,7 +26,7 @@ class BaseOrchestrationPlay:
     HEADERS = ['  #', 'INSTANCE', 'SERVICE', 'SHIP', 'CONTAINER', 'STATUS']
 
     LINE_FMT = ('{:>3d}. \033[;1m{:<20.20s}\033[;0m {:<20.20s} {:<20.20s}'
-                if sys.stdout.isatty() else
+                if supports_color() else
                 '{:>3d}. {:<20.20s} {:<20.20s} {:<20.20s}')
 
     def __init__(self, containers=[], forward=True, ignore_dependencies=False,

--- a/maestro/termoutput.py
+++ b/maestro/termoutput.py
@@ -6,9 +6,14 @@ import datetime
 import threading
 import re
 import sys
+import os
 
 
 STRIP_COLORS = re.compile(r'\033\[[0-9;]+m')
+
+
+def supports_color(out=sys.stdout):
+    return out.isatty() or 'ANSICON' in os.environ
 
 
 def color(n, s, bold=True):
@@ -88,17 +93,17 @@ class OutputManager:
         return f
 
     def start(self):
-        if not self._out.isatty():
+        if not supports_color(self._out):
             return
         self._print('{}\033[{}A'.format('\n' * self._lines, self._lines))
 
     def end(self):
-        if not self._out.isatty():
+        if not supports_color(self._out):
             return
         self._print('\033[{}B'.format(self._lines))
 
     def _print(self, s, pos=None):
-        if not self._out.isatty():
+        if not supports_color(self._out):
             s = STRIP_COLORS.sub('', s)
             self._out.write(s + '\n')
             self._out.flush()


### PR DESCRIPTION
requiring isatty is too restrictive to determine if the terminal supports ansi, but actually determining ansi support is a pit of snakes, so this respects one environment variable that indicates it ala https://github.com/django/django/blob/master/django/core/management/color.py and thereby allows you to force it on if necessary
