### PR TITLE
Possibility to set restart policy from configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ be placed on (by name). Additionally, it may define:
   - `net`, to specify the container's network mode (one of `bridge` --
     the default, `host`, `container:<name|id>` or `none` to disable
     networking altogether);
+  - `restart`, to specify the restart policy (see Restart Policy below)
   - `dns`, to specify one (as a single IP address) or more DNS servers
     (as a list) to be declared inside the container.
 
@@ -250,6 +251,7 @@ services:
           cpu: 10
         dns: [ 8.8.8.8, 8.8.4.4 ]
         net: host
+        restart: {name: on-failure, maximum_retry_count: 3}
 ```
 
 ## Defining dependencies
@@ -535,6 +537,20 @@ of zero indicates success, as per the Unix convention). For example:
 ```yaml
 type: exec
 command: "python my_cool_script.py"
+```
+
+## Restart Policy
+Since version 1.2 docker allows to define the restart policy once a container stops.
+Allowed values are:
+
+  * `restart: no`, container is never restarted when stopped (default behaviour);
+  * `restart: always`, container is always restarted when stopped;
+  * `restart: on-failure`, container is restarted when stopped because of a failure.
+
+You can also specify the number of maximum retries for restarting the container before giving up (in this case 3):
+
+```yaml
+    restart: { name: on-failure, maximum_retry_count: 3}
 ```
 
 ## How Maestro orchestrates and service auto-configuration

--- a/maestro/exceptions.py
+++ b/maestro/exceptions.py
@@ -36,3 +36,7 @@ class InvalidPortSpecException(MaestroException):
 class InvalidLifecycleCheckConfigurationException(MaestroException):
     "Error thrown when a lifecycle check isn't configured properly."""
     pass
+
+
+class InvalidRestartPolicyConfigurationException(MaestroException):
+    "Error thrown when a restart policy isn't configured properly."""

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -213,6 +213,7 @@ class StartTask(Task):
             port_bindings=ports,
             privileged=self.container.privileged,
             network_mode=self.container.network_mode,
+            restart_policy=self.container.restart_policy,
             dns=self.container.dns,
             links=self.container.links)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docker-py>=0.3.2
+docker-py>=0.5.0
 pyyaml
 jinja2
 six

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -121,6 +121,64 @@ class ContainerTest(unittest.TestCase):
                                        service, config=config)
         self.assertEqual(container.memswap_limit, 42*1024)
 
+    def test_restart_policy_default(self):
+        config = {}
+        service = entities.Service('foo', 'stackbrew/ubuntu', env={})
+        container = entities.Container('foo1', entities.Ship('ship', 'shipip'),
+                                       service, config=config)
+        self.assertEqual(container.restart_policy, { 'Name': 'no', 'MaximumRetryCount': 0})
+
+    def test_restart_policy_no(self):
+        config = {'restart': 'no'}
+        service = entities.Service('foo', 'stackbrew/ubuntu', env={})
+        container = entities.Container('foo1', entities.Ship('ship', 'shipip'),
+                                       service, config=config)
+        self.assertEqual(container.restart_policy, { 'Name': 'no', 'MaximumRetryCount': 0})
+        
+    def test_restart_policy_always(self):
+        config = {'restart': 'always'}
+        service = entities.Service('foo', 'stackbrew/ubuntu', env={})
+        container = entities.Container('foo1', entities.Ship('ship', 'shipip'),
+                                       service, config=config)
+        self.assertEqual(container.restart_policy, { 'Name': 'always', 'MaximumRetryCount': 0})
+        
+    def test_restart_policy_onfailure(self):
+        config = {'restart': 'on-failure'}
+        service = entities.Service('foo', 'stackbrew/ubuntu', env={})
+        container = entities.Container('foo1', entities.Ship('ship', 'shipip'),
+                                       service, config=config)
+        self.assertEqual(container.restart_policy, { 'Name': 'on-failure', 'MaximumRetryCount': 0})
+
+    def test_restart_policy_onfailure_with_max_retries(self):
+        config = {'restart': {'name': 'on-failure', 'maximum_retry_count': 42}}
+        service = entities.Service('foo', 'stackbrew/ubuntu', env={})
+        container = entities.Container('foo1', entities.Ship('ship', 'shipip'),
+                                       service, config=config)
+        self.assertEqual(container.restart_policy, { 'Name': 'on-failure', 'MaximumRetryCount': 42})
+
+    def test_restart_policy_wrong_type(self):
+        config = {'restart': [] }
+        service = entities.Service('foo', 'stackbrew/ubuntu', env={})
+        self.assertRaises(
+		exceptions.InvalidRestartPolicyConfigurationException, 
+                lambda : entities.Container('foo1', entities.Ship('ship', 'shipip'),
+                                             service, config=config))
+
+    def test_restart_policy_wrong_structure(self):
+        config = {'restart': { 'name': 'no' } }
+        service = entities.Service('foo', 'stackbrew/ubuntu', env={})
+        self.assertRaises(
+		exceptions.InvalidRestartPolicyConfigurationException, 
+                lambda : entities.Container('foo1', entities.Ship('ship', 'shipip'),
+                                             service, config=config))
+
+    def test_restart_policy_wrong_name(self):
+        config = {'restart': 'noclue' } 
+        service = entities.Service('foo', 'stackbrew/ubuntu', env={})
+        self.assertRaises(
+		exceptions.InvalidRestartPolicyConfigurationException, 
+                lambda : entities.Container('foo1', entities.Ship('ship', 'shipip'),
+                                             service, config=config))
 
 class BaseConfigFileUsingTest(unittest.TestCase):
 


### PR DESCRIPTION
 docker-py 0.5.0 required, 
it has effect only with docker 1.2.0 
