### PR TITLE
Allow tls over ssh tunnel

### DIFF
--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -96,8 +96,11 @@ class Ship(Entity):
                 host_port=self._docker_port,
                 silent=True,
                 identity_file=ssh_tunnel['key'])
-            self._backend_url = 'http://localhost:{}'.format(
-                self._tunnel.bind_port)
+            
+            # Make sure we use https through the tunnel, if tls is enabled
+            proto = "https" if (tls or tls_verify) else "http"
+            self._backend_url = '{:s}://localhost:{:d}'.format(
+                proto, self._tunnel.bind_port)            
 
             # Apparently bgtunnel isn't always ready right away and this
             # drastically cuts down on the timeouts


### PR DESCRIPTION
We are using Maestro for an internal project. We cannot simply expose docker over a tcp connection (that's against internal policy) so we opted for the ssh tunnel. However, we also wanted to be able to verify the client's identity via tls. This change allows us to do both.
