### PR TITLE
Running Maestro-ng as a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.2
+MAINTAINER Arthur CARANTA <arthur@caranta.com>
+ENV DEBIAN_FRONTEND noninteractive
+ENV INITRD no
+RUN apk update && apk add py-pip gcc python-dev linux-headers musl-dev
+RUN pip install maestro-ng
+
+ENTRYPOINT ["/usr/bin/maestro" ]

--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ If you encounter this problem, simply install the package without the
 $ pip install --upgrade git+git://github.com/signalfx/maestro-ng
 ```
 
+### Use as a Docker container
+
+First, build your maestro-ng image using :
+```
+docker build -t maestro-ng .
+```
+
+Then say you have a maestro-ng configuration named /fu/bar/myconf.yml
+
+If you want to start this on a docker host without install python and its pip modules :
+```
+docker run --rm -t -i -v /fu/bar/myconf.yml:/maestro.yaml maestro-ng <start/stop/status/clean>
+```
+or, if the myconf.yml is in the current dir :
+```
+docker run --rm -t -i -v $(pwd)/myconf.yml:/maestro.yaml maestro-ng <start/stop/status/clean>
+```
+
 ## Documentation
 
 The [MaestroNG documentation](http://maestro-ng.readthedocs.org/) is


### PR DESCRIPTION
As it was suggested in #163  here is my solution in the form of a Dockerfile and a bit of help added to the Readme file.

FYI, this maestro-ng container is used in our company since well ... around a year and a half.
It work for us, therefore I thought I could share ;)

Can be tried live from : https://hub.docker.com/r/acaranta/dockmaestro/
