### PR TITLE
Added rexec to allow execute script inside of container.

### DIFF
--- a/docs/lifecycle_checks.rst
+++ b/docs/lifecycle_checks.rst
@@ -119,3 +119,29 @@ more information.
 Note that the current working directory is never changed by Maestro
 directly; paths to your scripts will be resolved from wherever you run
 Maestro, not from where the environment YAML file lives.
+
+Remote script execution
+--------------------------------------------------------------------------------
+
+Remote script execution (``type: rexec``) makes Maestro execute the given
+script inside of running container, using the script output to denote the
+success or failure of the test. Same as :doc:`Script execution`, the script
+is executed a certain number of attempts (defaulting to 180), with a
+delay between each attempt of 1 second. For example:
+
+.. code-block:: yaml
+
+  type: rexec
+  command: "python my_cool_remote_script_in_container.py"
+  attempts: 30
+
+Also, the script's execution environment is extended with the same
+environment that running container would have, which means it
+contains all the environment information about the container's
+configuration, ports, dependencies, etc. You can then use Maestro guest
+utility functions to easily grok that information from the environment
+(in Python). See :doc:`orchestration` and :doc:`guest_functions` for
+more information.
+
+Note that minimal ``api_version`` is '1.16'. See :doc:`environment` for
+more information.

--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -606,7 +606,8 @@ class Container(Entity):
             thread._children = weakref.WeakKeyDictionary()
 
         pool = multiprocessing.pool.ThreadPool()
-        return pool.map_async(lambda check: check.test(),
+
+        return pool.map_async(lambda check: check.test(self),
                               self._lifecycle[state])
 
     def ping_port(self, port):


### PR DESCRIPTION
Besides allowing operator to execute script [on the path where maestro-ng runs](http://maestro-ng.readthedocs.io/en/latest/lifecycle_checks.html?highlight=lifecycle), it would be nice to add the feature that allows operator to execute the script inside of running container. 

Therefore, a check script could be added to check the status of 'required' service before starting. For example, check whether 'zookeeper' is fully stated before starting kafka.  

```  
  kafka:
    image: docker.cenx.localnet:5000/kafka:latest
    requires: [ zookeeper ]
    lifecycle:
      running: [{type: rexec, command: "python check.py"}]
    instances:
      kafka1:
        ship: machine
        ports: {client: 4082}
        lifecycle:
          running: [{type: tcp, port: client}]
```

NOTE: 'check.py' exists inside 'kafka' container. 