### PR TITLE
Allow dns_opt options

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,17 @@
 ChangeLog
 =========
 
+Maestro 0.4.2
+-------------
+
+_November 29th, 2016_
+
+* Added ability to define port mappings at the service level (#165).
+* Fix for script exec auditor, should only execute on success of the
+  Maestro action.
+* Added support for the newly introduced unless-stopped container
+  restart policy (#181).
+
 Maestro 0.4.1
 -------------
 

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -193,7 +193,7 @@ class StartTask(Task):
             image = self.container.get_image_details()
             if self._refresh or \
                 not filter(
-                    lambda i: self.container.image in i['RepoTags'],
+                    lambda i: self.container.image in (i['RepoTags'] or []),
                     self.container.ship.backend.images(image['repository'])):
                 PullTask(self.o, self.container, self._registries,
                          standalone=False).run()

--- a/maestro/version.py
+++ b/maestro/version.py
@@ -1,2 +1,2 @@
 name = 'maestro-ng'
-version = '0.4.1'
+version = '0.4.2'

--- a/maestro/version.py
+++ b/maestro/version.py
@@ -1,2 +1,2 @@
 name = 'maestro-ng'
-version = '0.4.2'
+version = '0.4.2pushd1'


### PR DESCRIPTION
This allows a user to specify `dns_opt` options, passed through to [docker.py](http://docker-py.readthedocs.io/en/stable/containers.html?highlight=dns_opt)

`dns_opt` options are supported in docker api version 1.21 and later