### PR TITLE
Handle images from public registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.tox
 
 docs/_build
+.idea/

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -435,6 +435,8 @@ class LoginTask(Task):
 
         When nothing is configured, no retries are attempted (by virtue of the
         'when' list being empty)."""
+        if registry is None:
+            registry = {}
         spec = registry.get('retry', {})
         spec['attempts'] = int(spec.get('attempts', _DEFAULT_RETRY_ATTEMPTS))
         spec['when'] = set(spec.get('when', []))

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -30,6 +30,7 @@ from ..termoutput import green, blue, red, time_ago
 CONTAINER_STATUS_FMT = '{:<25s} '
 TASK_RESULT_FMT = '{:<10s}'
 _DEFAULT_RETRY_ATTEMPTS = 3
+_DEFAULT_RETRY_SPEC = {'attempts': _DEFAULT_RETRY_ATTEMPTS, 'when': set([])}
 
 
 class Task:
@@ -435,8 +436,9 @@ class LoginTask(Task):
 
         When nothing is configured, no retries are attempted (by virtue of the
         'when' list being empty)."""
-        if registry is None:
-            registry = {}
+        if not registry:
+            return _DEFAULT_RETRY_SPEC
+
         spec = registry.get('retry', {})
         spec['attempts'] = int(spec.get('attempts', _DEFAULT_RETRY_ATTEMPTS))
         spec['when'] = set(spec.get('when', []))


### PR DESCRIPTION
The new 'retry attempts' feature checks the registry definition if there is a retry policy defained. But if the image is from public registry (aka docker hub), the registry will be None, thus the check will fail.

I'm not  a python programmer, so i don't know if my fix is idiomatic, but it works :)