### PR TITLE
Allow custom jinja filters to be used for parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.tox
 
 docs/_build
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
 install: "pip install tox-travis"
 script: tox
 sudo: false

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+_Unreleased_
+
+* Bump minimum Docker API version requirement to 1.18 to support
+  container labels.
+
 Maestro 0.6.0
 -------------
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,20 @@
 ChangeLog
 =========
 
+Maestro 0.6.0
+-------------
+
+_November 23rd, 2018_
+
+* Performance improvements by using PyYAML's CParser.
+* Performance improvements by caching `get_link_variables()`
+* when creating each container instance's environment variables
+  (by @tedoc2000).
+* Ability to define extra `/etc/hosts` entry by ship reference (requires
+  the ship to be defined using a numeric IP address).
+* Added check for duplicate service instances names across services.
+* Fix for the output column width calculations (by @hgolson77).
+
 Maestro 0.5.4
 -------------
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,10 +1,14 @@
 ChangeLog
 =========
 
-_Unreleased_
+Maestro 0.7.0
+-------------
 
 * Bump minimum Docker API version requirement to 1.18 to support
   container labels.
+* Handle public images correctly (by @sassrobi).
+* Add support for setting container labels (#202).
+* Fixed some flake8 styling issues from previous changes.
 
 Maestro 0.6.0
 -------------

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -287,6 +287,8 @@ on (by name). Additionally, each instance may define:
 - ``username``, to set the name of the user under which the container's
   processes will run.
 
+- ``labels``, a list or a map (dictionary) of labels to set on the container.
+
 For example:
 
 .. code-block:: yaml
@@ -304,6 +306,8 @@ For example:
           limits:
             memory: 1g
             cpu: 2
+          labels:
+            - no-relocate
         zk-2:
           ship: vm2.ore1
           ports: {client: 2181, peer: 2888, leader_election: 3888}
@@ -314,6 +318,8 @@ For example:
           limits:
             memory: 1g
             cpu: 2
+          labels:
+            - no-relocate
       lifecycle:
         running: [{type: tcp, port: client}]
     kafka:

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -5,7 +5,7 @@ Environment description
 ================================================================================
 
 The environment is described using YAML. The description of the environment
-follows a specific, versionned *schema*. The default schema version, if not
+follows a specific, versioned *schema*. The default schema version, if not
 specified, is version 1. The most recent version of the schema, described by
 this documentation, is version 2. To declare what schema version to use for
 your YAML environment description file, use the following header:

--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -175,7 +175,7 @@ class Ship(Entity):
         images = {}
         for image in self._backend.images():
             tags = image.get('RepoTags', [])
-            if not tags or tags is '<none>:<none>':
+            if not tags or tags == '<none>:<none>':
                 continue
             for tag in image['RepoTags']:
                 images[tag] = image['Id']

--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -471,6 +471,13 @@ class Container(Entity):
         # Ulimits options
         self.ulimits = self._parse_ulimits(config.get('ulimits', None))
 
+        # Container labels; may be a dictionary or a list
+        self.labels = config.get('labels', None)
+        if self.labels is not None and type(self.labels) not in [list, dict]:
+            raise exceptions.EnvironmentConfigurationException(
+                    ('Invalid labels configuration for container {}; '
+                     'must be a list or mapping! ').format(self.name))
+
         # host_config now contains all settings previously passed in container
         # start().
         self.host_config = self._ship.backend.create_host_config(

--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -69,7 +69,7 @@ class Ship(Entity):
 
     DEFAULT_DOCKER_PORT = 2375
     DEFAULT_DOCKER_TLS_PORT = 2376
-    DEFAULT_API_VERSION = 1.15
+    DEFAULT_API_VERSION = 1.18
     DEFAULT_DOCKER_TIMEOUT = 5
 
     def __init__(self, name, ip, endpoint=None, docker_port=None,

--- a/maestro/exceptions.py
+++ b/maestro/exceptions.py
@@ -57,29 +57,31 @@ class ContainerOrchestrationException(OrchestrationException):
         return '{}: {}'.format(self.container.name, self.message)
 
 
-class InvalidPortSpecException(MaestroException):
+class InvalidPortSpecException(EnvironmentConfigurationException):
     """Error thrown when a port spec is in an invalid format."""
     pass
 
 
-class InvalidLifecycleCheckConfigurationException(MaestroException):
+class InvalidLifecycleCheckConfigurationException(
+        EnvironmentConfigurationException):
     """Error thrown when a lifecycle check isn't configured properly."""
     pass
 
 
-class InvalidRestartPolicyConfigurationException(MaestroException):
+class InvalidRestartPolicyConfigurationException(
+        EnvironmentConfigurationException):
     """Error thrown when a restart policy isn't configured properly."""
     pass
 
 
-class InvalidVolumeConfigurationException(MaestroException):
+class InvalidVolumeConfigurationException(EnvironmentConfigurationException):
     """Error thrown when a volume binding isn't configured properly."""
 
 
-class InvalidAuditorConfigurationException(MaestroException):
+class InvalidAuditorConfigurationException(EnvironmentConfigurationException):
     """Invalid configuration of one of the specified auditors."""
 
 
-class InvalidLogConfigurationException(MaestroException):
+class InvalidLogConfigurationException(EnvironmentConfigurationException):
     """Error thrown when a log_driver or log_opt is in an invalid format."""
     pass

--- a/maestro/loader.py
+++ b/maestro/loader.py
@@ -60,7 +60,7 @@ except ImportError:
             yaml.resolver.Resolver.__init__(self)
 
 
-def load(filename):
+def load(filename, filters=None):
     """Load a config from the given file.
 
     Args:
@@ -74,6 +74,8 @@ def load(filename):
         loader=jinja2.FileSystemLoader(os.path.dirname(filename)),
         auto_reload=False,
         extensions=['jinja2.ext.with_'])
+    if filters:
+        env.filters.update(**filters)
     try:
         if filename == '-':
             template = env.from_string(sys.stdin.read())

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -229,6 +229,7 @@ class StartTask(Task):
                 ports=ports,
                 detach=True,
                 working_dir=self.container.workdir,
+                labels=self.container.labels,
                 command=self.container.command)
 
         self.o.pending('waiting for container...')

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -435,6 +435,8 @@ class LoginTask(Task):
 
         When nothing is configured, no retries are attempted (by virtue of the
         'when' list being empty)."""
+        if registry is None:
+            registry = {}
         spec = registry.get('retry', {})
         spec['attempts'] = int(spec.get('attempts', _DEFAULT_RETRY_ATTEMPTS))
         spec['when'] = set(spec.get('when', []))

--- a/maestro/plays/tasks.py
+++ b/maestro/plays/tasks.py
@@ -30,6 +30,7 @@ from ..termoutput import green, blue, red, time_ago
 CONTAINER_STATUS_FMT = '{:<25s} '
 TASK_RESULT_FMT = '{:<10s}'
 _DEFAULT_RETRY_ATTEMPTS = 3
+_DEFAULT_RETRY_SPEC = {'attempts': _DEFAULT_RETRY_ATTEMPTS, 'when': set([])}
 
 
 class Task:
@@ -435,8 +436,9 @@ class LoginTask(Task):
 
         When nothing is configured, no retries are attempted (by virtue of the
         'when' list being empty)."""
-        if registry is None:
-            registry = {}
+        if not registry:
+            return _DEFAULT_RETRY_SPEC
+
         spec = registry.get('retry', {})
         spec['attempts'] = int(spec.get('attempts', _DEFAULT_RETRY_ATTEMPTS))
         spec['when'] = set(spec.get('when', []))

--- a/maestro/version.py
+++ b/maestro/version.py
@@ -2,4 +2,4 @@
 # Copyright (C) 2015-2018 SignalFx, Inc.
 
 name = 'maestro-ng'
-version = '0.6.0'
+version = '0.7.0'

--- a/maestro/version.py
+++ b/maestro/version.py
@@ -2,4 +2,4 @@
 # Copyright (C) 2015-2018 SignalFx, Inc.
 
 name = 'maestro-ng'
-version = '0.5.4'
+version = '0.6.0'

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -70,7 +70,7 @@ class ContainerTest(unittest.TestCase):
     SHIP = 'ship'
     SHIP_IP = '10.0.0.1'
     SCHEMA = {'schema': 2}
-    DOCKER_VERSION = '1.12'
+    DOCKER_VERSION = '1.18'
     PORTS = {'server': 4848}
 
     def _cntr(service_name=SERVICE, service_env=None, image=IMAGE,

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -373,6 +373,25 @@ class ContainerTest(unittest.TestCase):
                          {'foo': ContainerTest.SHIP_IP})
 
 
+    def test_invalid_labels(self):
+        six.assertRaisesRegex(self,
+                exceptions.EnvironmentConfigurationException,
+                'Invalid labels configuration',
+                lambda: self._cntr(config={'labels': 'foo'}))
+        six.assertRaisesRegex(self,
+                exceptions.EnvironmentConfigurationException,
+                'Invalid labels configuration',
+                lambda: self._cntr(config={'labels': 42}))
+
+    def test_list_labels(self):
+        container = self._cntr(config={'labels': ['foo']})
+        self.assertEqual(container.labels, ['foo'])
+
+    def test_dict_labels(self):
+        container = self._cntr(config={'labels': {'foo': 'bar'}})
+        self.assertEqual(container.labels, {'foo': 'bar'})
+
+
 class BaseConfigFileUsingTest(unittest.TestCase):
 
     def _get_config(self, name):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, flake8
+envlist = py27, py36, py37, flake8
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,3 @@ deps = -r{toxinidir}/requirements.txt
 [testenv:flake8]
 commands = flake8 maestro
 deps = flake8
-
-[testenv:py35]
-install_command = pip3 install {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,13 @@
 [tox]
-envlist = py27, py36, py37, flake8
+envlist = py{27,35,36,37}, flake8
 skip_missing_interpreters = true
+
+[travis]
+python =
+  2.7: py27, flake8
+  3.5: py35, flake8
+  3.6: py36, flake8
+  3.7: py37, flake8
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Added an optional "filters" argument to loader.load that allows callers to supply a dictionary of filter name -> filter methods. This allows clients to use their own custom jinja2 filters while parsing maestro templates