### PR TITLE
Allow custom jinja filters to be passed to load_config_from_file

### DIFF
--- a/maestro/loader.py
+++ b/maestro/loader.py
@@ -60,7 +60,7 @@ except ImportError:
             yaml.resolver.Resolver.__init__(self)
 
 
-def load(filename):
+def load(filename, filters=None):
     """Load a config from the given file.
 
     Args:
@@ -74,6 +74,8 @@ def load(filename):
         loader=jinja2.FileSystemLoader(os.path.dirname(filename)),
         auto_reload=False,
         extensions=['jinja2.ext.with_'])
+    if filters:
+        env.filters.update(**filters)
     try:
         if filename == '-':
             template = env.from_string(sys.stdin.read())


### PR DESCRIPTION
Added an optional "filters" argument to loader.load that allows callers to supply a dictionary of filter name -> filter methods. This allows clients to use their own custom jinja2 filters while parsing maestro templates