### PR TITLE
Conductor: fix _ordered_containers() to use fresh result list fo…

### DIFF
--- a/maestro/maestro.py
+++ b/maestro/maestro.py
@@ -153,7 +153,7 @@ class Conductor:
     def env_name(self):
         return self._config['name']
 
-    def _order_dependencies(self, pending=[], ordered=[], forward=True):
+    def _order_dependencies(self, pending=None, ordered=None, forward=True):
         """Order the given set of containers into an order respecting the
         service dependencies in the given direction.
 
@@ -165,6 +165,8 @@ class Conductor:
         be constructed for startup (dependencies first) or shutdown (dependents
         first).
         """
+        pending = pending or []
+        ordered = ordered or []
         wait = []
         for container in pending:
             deps = self._gather_dependencies([container], forward)


### PR DESCRIPTION
I would like to call _ordered_containers() method multiple times in my code, but each invocation of that method appends new results to a list with results accumulated from all previous invocations.

The problem is underneath in _order_dependencies() method, which declares mutable default empty list argument.