### PR TITLE
Add support for "read-only" containers

### DIFF
--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -247,6 +247,9 @@ on (by name). Additionally, each instance may define:
 - ``privileged``, a boolean specifying whether the container should run in
   privileged mode or not (defaults to ``false``);
 
+- ``read_only``, a boolean specifying whether the container root filesystem
+  should be mount as read only or not.
+
 - ``cap_add``, Linux capabilities to add to the container (see the documentation
   for `docker run`_;
 
@@ -313,6 +316,7 @@ For example:
           ship: vm1.ore1
           ports: {client: 2181, peer: 2888, leader_election: 3888}
           privileged: true
+          read_only: true
           volumes:
             /data/zookeeper: /var/lib/zookeeper
           limits:

--- a/maestro/entities.py
+++ b/maestro/entities.py
@@ -431,6 +431,9 @@ class Container(Entity):
         # Should this container run with -privileged?
         self.privileged = config.get('privileged', False)
 
+        # Should this container run with --read-only ?
+        self.read_only = config.get('read_only', False)
+
         # Add or drop privileges
         self.cap_add = config.get('cap_add', None)
         self.cap_drop = config.get('cap_drop', None)
@@ -501,6 +504,7 @@ class Container(Entity):
             port_bindings=ports,
             lxc_conf=self.lxc_conf,
             privileged=self.privileged,
+            read_only=self.read_only,
             cap_add=self.cap_add,
             cap_drop=self.cap_drop,
             extra_hosts=self.extra_hosts,


### PR DESCRIPTION
It would be great to be able to run "read-only" container like you can do with the command `docker run --read-only`.

This can be used to force container to write data inside well know mount path instead of `/var/lib/docker`.