### PR TITLE
Add ability to filter container names

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,17 @@
 ChangeLog
 =========
 
+Maestro 0.8.0
+-------------
+* Added --container-filter option to allow the filtering
+  of container names based on python fnmatch syntax.
+  E.g *foo* will match only containers that contain foo
+* Added --ship-filter option to allow the filtering
+  of container names based on their ship name using
+  python fnmatch syntax.
+  E.g *foo* will match only containers whose ship contains
+  foo
+
 Maestro 0.7.5
 -------------
 

--- a/maestro/__main__.py
+++ b/maestro/__main__.py
@@ -47,6 +47,14 @@ def create_parser():
         'things', nargs='*', metavar='thing',
         help='container(s) or service(s) to act on')
 
+    filterable = argparse.ArgumentParser(add_help=False)
+    filterable.add_argument(
+        '-C', '--container-filter',
+        help='filter for container names. Uses fnmatch semantics')
+    filterable.add_argument(
+        '-S', '--ship-filter',
+        help='filter for container names by ship name. Uses fnmatch semantics')
+
     expandable = argparse.ArgumentParser(add_help=False)
     expandable.add_argument(
         '-s', '--expand-services', action='store_true',
@@ -78,7 +86,7 @@ def create_parser():
 
     # status
     subparser = subparsers.add_parser(
-        parents=[common, concurrent],
+        parents=[common, concurrent, filterable],
         name='status',
         description='Display container status',
         help='display container status')
@@ -91,14 +99,14 @@ def create_parser():
 
     # pull
     subparser = subparsers.add_parser(
-        parents=[common, concurrent],
+        parents=[common, concurrent, filterable],
         name='pull',
         description='Pull container images from registry',
         help='pull container images from registry')
 
     # start
     subparser = subparsers.add_parser(
-        parents=[common, concurrent, with_refresh],
+        parents=[common, concurrent, with_refresh, filterable],
         name='start',
         description='Start services and containers',
         help='start services and containers')
@@ -112,14 +120,14 @@ def create_parser():
 
     # kill
     subparser = subparsers.add_parser(
-        parents=[common, concurrent, expandable],
+        parents=[common, concurrent, expandable, filterable],
         name='kill',
         description='Kill services and containers',
         help='kills the services and containers')
 
     # restart
     subparser = subparsers.add_parser(
-        parents=[common, concurrent, expandable, with_refresh],
+        parents=[common, concurrent, expandable, with_refresh, filterable],
         name='restart',
         description='Restart services and containers',
         help='restart services and containers')
@@ -135,7 +143,7 @@ def create_parser():
 
     # clean
     subparser = subparsers.add_parser(
-        parents=[common, concurrent],
+        parents=[common, concurrent, filterable],
         name='clean',
         description='Cleanup and remove stopped containers',
         help='remove stopped containers')

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -549,6 +549,30 @@ class ConductorTest(BaseConfigFileUsingTest):
             'OVERRIDE': 'cat'
         })
 
+    def test_container_filter(self):
+        config = self._get_config('container_filter')
+        c = maestro.Conductor(config)
+
+        #No filter
+        containers = c._to_containers(['webapp'], True, None, None)
+        self.assertEquals(len(containers), 2)
+
+        #Filter on container name
+        containers = c._to_containers(['webapp'], True, '*-a', None)
+        self.assertEquals(len(containers), 1)
+        self.assertEquals(containers[0].name, 'webapp-a')
+
+        #Filter on container's ship name
+        containers = c._to_containers(['webapp'], True, None, 'ship*2')
+        self.assertEquals(len(containers), 1)
+        self.assertEquals(containers[0].name, 'webapp-b')
+
+        #Filter on container name and container's ship name
+        containers = c._to_containers(['webapp', 'webapp1'], True, '*-b', 
+                                      'ship*2')
+        self.assertEquals(len(containers), 2)
+        container_names = set([c.name for c in containers])
+        self.assertEquals(container_names, {'webapp-b', 'webapp1-b'})
 
 class ConfigTest(BaseConfigFileUsingTest):
 

--- a/tests/yaml/container_filter.yaml
+++ b/tests/yaml/container_filter.yaml
@@ -1,0 +1,26 @@
+
+name: test-container-filtering
+ships:
+  ship1:
+     ip: "ship-ab"
+  ship2:
+     ip: "ship-bb"
+services:
+  webapp:
+     image: foo
+     instances:
+       webapp-a:
+         ship: ship1
+         ports: {http: 3344}
+       webapp-b:
+         ship: ship2
+         ports: {http: 3344}
+  webapp1:
+     image: foo
+     instances:
+       webapp1-a:
+         ship: ship1
+         ports: {http: 3345}
+       webapp1-b:
+         ship: ship2
+         ports: {http: 3345}


### PR DESCRIPTION
Added new -C/--container-filter global option to allow users
to filter container names using python fnmatch syntax.
E.g -F *foo* will match only containers that contain foo
Note this will only work when no dependencies are involved

Added -S/--ship-filter option to allow the filtering
of container names based on their ship name using
python fnmatch syntax.
E.g *foo* will match only containers whose ship contains
foo